### PR TITLE
Don't include `://missing value` in the list of currently open Safari tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.0.1 (2017-04-30)
+
+*   Bugfix: don't include `://missing value` in the list of currently open Safari tabs.
+
 ## v2.0.0 (2017-04-30)
 
 *   A near-complete rewrite that overhauls the command-line parsing, improves the interface, and has better error reporting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+## v2.0.0 (2017-04-30)
+
+*   A near-complete rewrite that overhauls the command-line parsing, improves the interface, and has better error reporting.
+*   Replace the `furl` and `2url` commands with a more generic `url` command with configurable `--window` and `--tab` parameters.
+*   Rename the `list-tabs` command to `urls-all`.
+*   Add a new `icloud-tabs` command for getting data about iCloud Tabs.
+*   Strip UTM tracking parameters from all URLs.
+*   Bugfix: don't panic when processing a YouTube URL that isn't a video.
+
+## v1.2.0 (2017-02-25)
+
+*   Add a `reading-list` command that a list of URLs from Reading List.
+
+## v1.1.0 (2017-02-23)
+
+*   Renamed from `safari-url` to `safari`.
+*   Add a `clean-tabs` command that closes tabs whose URLs match a particular pattern.
+*   Add a `list-tabs` command that gets a list of URLs in every open tab.
+*   Strip tracking data from Buzzfeed and Mashable URLs.
+
+## v1.0.0 (2017-02-20)
+
+*   Initial release (under the name `safari-url`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "safari"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "docopt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "plist 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "safari"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "docopt 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "plist 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safari"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Alex Chan <alex@alexwlchan.net>"]
 
 [dependencies]

--- a/src/safari.rs
+++ b/src/safari.rs
@@ -95,6 +95,7 @@ pub fn get_all_urls() -> Vec<String> {
                  .split(", ")
                  .map(|url| urls::tidy_url(url))
                  .filter(|url| url != "favorites://")
+                 .filter(|url| url != "://missing value")
                  .collect()
   } else {
     error!("Unexpected error from osascript: {:?}", output.stderr);


### PR DESCRIPTION
Resolves #20.