### PR TITLE
Change the way we look up tabs in the 'list-tabs' command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -53,8 +53,8 @@ pub struct Args {
   pub cmd_close_tabs: bool,
   pub cmd_icloud_tabs: bool,
   pub cmd_reading_list: bool,
-  pub flag_window: Option<i32>,
-  pub flag_tab: Option<i32>,
+  pub flag_window: Option<u32>,
+  pub flag_tab: Option<u32>,
   pub flag_version: bool,
   pub flag_list_devices: bool,
   pub flag_device: Option<String>,
@@ -74,9 +74,6 @@ pub fn parse_args(name: &str) -> Args {
       Some(v) => {
         if v == 0 {
           args.flag_window = None;
-        } else if v < 0 {
-          let err_message = format!("--window must be greater than 0; got {}.", v);
-          Error::Usage(err_message).exit();
         };
       },
       None => {},
@@ -85,9 +82,6 @@ pub fn parse_args(name: &str) -> Args {
       Some(v) => {
         if v == 0 {
           args.flag_tab = None;
-        } else if v < 0 {
-          let err_message = format!("--tab must be greater than 0; got {}.", v);
-          Error::Usage(err_message).exit();
         };
       },
       None => {},

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,14 +56,9 @@ fn main() {
 
   if args.cmd_list_tabs {
     assert_safari_is_running();
-    match safari::get_all_urls() {
-      Ok(urls) => {
-        for url in urls {
-          println!("{}", url);
-        }
-      },
-      Err(e) => error!("{}", e),
-    };
+    for url in safari::get_all_urls() {
+      println!("{}", url);
+    }
   }
 
   if args.cmd_close_tabs {

--- a/src/safari.rs
+++ b/src/safari.rs
@@ -42,7 +42,7 @@ pub fn is_safari_running() -> bool {
 ///              frontmost window.
 /// * `tab` - Tab index.  1 is leftmost.  If None, assumes the frontmost tab.
 ///
-pub fn get_url(window: Option<i32>, tab: Option<i32>) -> Result<String, String> {
+pub fn get_url(window: Option<u32>, tab: Option<u32>) -> Result<String, String> {
   // If a tab isn't specified, assume the user wants the frontmost tab.
   let command = match window {
     Some(w_idx) => {

--- a/src/scripts/list-open-tabs.scpt
+++ b/src/scripts/list-open-tabs.scpt
@@ -1,9 +1,0 @@
-set listOfUrls to {}
-
-tell application "Safari"
-  repeat with t in tabs of windows
-    copy (URL of t) to the end of listOfUrls
-  end repeat
-end tell
-
-get listOfUrls


### PR DESCRIPTION
Rather than getting them all in one big AppleScript and parsing the output, instead we make a series of calls to `osascript` – get tab 1 of window 1, tab 2 of window 1, …, tab M of window N. This means we can tighten up the cleaning pipeline, and throw away some crappy parsing code.

This will make some changes for #45 a bit easier.