### PR TITLE
Replace mobile.nytimes.com links by their non-mobile counterparts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.2.2 (2017-10-07)
+
+*   URL tweak: mobile.nytimes.com links are now replaced by non-mobile versions.
+    ([#59](https://github.com/alexwlchan/safari.rs/issues/59))
+
 ## v2.2.1 (2017-08-29)
 
 *   URL tweak: Remove the `_ga` tracking parameter from shared URLs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "safari"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "docopt 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "plist 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "safari"
-version = "2.2.1"
+version = "2.2.2"
 authors = ["Alex Chan <alex@alexwlchan.net>"]
 
 [dependencies]

--- a/src/urls.rs
+++ b/src/urls.rs
@@ -461,4 +461,14 @@ tidy_url_tests! {
     "https://example.org?_ga=1234&foo=bar",
     "https://example.org?foo=bar"
   ),
+
+  nytimes_mobile_url: (
+    "https://mobile.nytimes.com/2017/02/24/style/modern-love-when-your-greatest-romance-is-friendship.html",
+    "https://nytimes.com/2017/02/24/style/modern-love-when-your-greatest-romance-is-friendship.html"
+  ),
+
+  nytimes_non_mobile_url: (
+    "https://nytimes.com/2017/02/24/style/modern-love-when-your-greatest-romance-is-friendship.html",
+    "https://nytimes.com/2017/02/24/style/modern-love-when-your-greatest-romance-is-friendship.html"
+  ),
 }

--- a/src/urls.rs
+++ b/src/urls.rs
@@ -58,6 +58,11 @@ pub fn tidy_url(url: &str) -> String {
     parsed_url.netloc = String::from("twitter.com");
   }
 
+  // Always get the non-mobile version of nytimes.com URLs
+  if parsed_url.netloc == "mobile.nytimes.com" {
+    parsed_url.netloc = String::from("nytimes.com");
+  }
+
   // Remove any tracking junk from Amazon URLs so they're not a
   // ridiculous length
   if parsed_url.netloc == "www.amazon.co.uk" {


### PR DESCRIPTION
Resolves #59.